### PR TITLE
go: Correct module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module kube-review
+module github.com/anderseknert/kube-review
 
 go 1.22.0
 


### PR DESCRIPTION
Without this, the module cannot be 'go installed'.

```
$ go install github.com/anderseknert/kube-review@latest
go: downloading github.com/anderseknert/kube-review v0.3.0 go: github.com/anderseknert/kube-review@latest: version constraints conflict:
        github.com/anderseknert/kube-review@v0.3.0: parsing go.mod:
        module declares its path as: kube-review
                but was required as: github.com/anderseknert/kube-review
```